### PR TITLE
Load joint limits from a configuration file

### DIFF
--- a/reach_description/config/alpha_5/joint_limits.yaml
+++ b/reach_description/config/alpha_5/joint_limits.yaml
@@ -1,0 +1,16 @@
+joint_limits:
+  axis_e:
+    max_position: 6.10
+    min_position: 0.0
+  axis_d:
+    max_position: 3.49
+    min_position: -3.49
+  axis_c:
+    max_position: 3.22
+    min_position: 0.0
+  axis_b:
+    max_position: 3.22
+    min_position: 0.0
+  axis_a:
+    max_position: 0.015
+    min_position: 0.0

--- a/reach_description/description/alpha_5/ros2_control.xacro
+++ b/reach_description/description/alpha_5/ros2_control.xacro
@@ -2,13 +2,19 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="alpha_5_system"
-               params="prefix serial_port initial_positions_file use_sim:=^|false use_mock_hardware:=^true">
+               params="prefix serial_port initial_positions_file joint_limits_file use_sim:=^|false use_mock_hardware:=^true">
 
     <!-- load the initial positions for simulation -->
     <xacro:property name="initial_positions_file"
                     default="$(arg initial_positions_file)" />
     <xacro:property name="initial_positions"
                     value="${xacro.load_yaml(initial_positions_file)['initial_positions']}" />
+
+    <!-- load the joint limits -->
+    <xacro:property name="joint_limits_file"
+                    default="$(arg joint_limits_file)" />
+    <xacro:property name="joint_limits"
+                    value="${xacro.load_yaml(joint_limits_file)['joint_limits']}" />
 
     <ros2_control name="ReachAlpha5"
                   type="system">
@@ -38,8 +44,8 @@
       <joint name="${prefix}axis_a">
         <param name="device_id">1</param>
         <command_interface name="position">
-          <param name="min">0</param>
-          <param name="max">0.015</param>
+          <param name="min">${joint_limits['axis_a']['min_position']}</param>
+          <param name="max">${joint_limits['axis_a']['max_position']}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-0.003</param>
@@ -60,8 +66,8 @@
       <joint name="${prefix}axis_b">
         <param name="device_id">2</param>
         <command_interface name="position">
-          <param name="min">0</param>
-          <param name="max">3.22</param>
+          <param name="min">${joint_limits['axis_b']['min_position']}</param>
+          <param name="max">${joint_limits['axis_b']['max_position']}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-0.8726646</param>
@@ -82,8 +88,8 @@
       <joint name="${prefix}axis_c">
         <param name="device_id">3</param>
         <command_interface name="position">
-          <param name="min">0</param>
-          <param name="max">3.22</param>
+          <param name="min">${joint_limits['axis_c']['min_position']}</param>
+          <param name="max">${joint_limits['axis_c']['max_position']}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-0.5235988</param>
@@ -104,8 +110,8 @@
       <joint name="${prefix}axis_d">
         <param name="device_id">4</param>
         <command_interface name="position">
-          <param name="min">0</param>
-          <param name="max">3.49</param>
+          <param name="min">${joint_limits['axis_d']['min_position']}</param>
+          <param name="max">${joint_limits['axis_d']['max_position']}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-0.5235988</param>
@@ -126,8 +132,8 @@
       <joint name="${prefix}axis_e">
         <param name="device_id">5</param>
         <command_interface name="position">
-          <param name="min">0</param>
-          <param name="max">6.14</param>
+          <param name="min">${joint_limits['axis_e']['min_position']}</param>
+          <param name="max">${joint_limits['axis_e']['max_position']}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-0.5235988</param>

--- a/reach_description/description/alpha_5/standard_jaws/alpha_5.config.xacro
+++ b/reach_description/description/alpha_5/standard_jaws/alpha_5.config.xacro
@@ -21,6 +21,8 @@
              default="world" />
   <xacro:arg name="controllers_file"
              default="$(find reach_description)/config/alpha_5/controllers.yaml" />
+  <xacro:arg name="joint_limits_file"
+             default="$(find reach_description)/config/alpha_5/joint_limits.yaml" />
   <xacro:arg name="mount_rotation"
              default="0" />
 
@@ -38,7 +40,8 @@
 
   <!-- arm -->
   <xacro:alpha_5_urdf parent="$(arg parent)"
-                      prefix="${prefix}">
+                      prefix="${prefix}"
+                      joint_limits_file="$(arg joint_limits_file)">
     <origin xyz="0.0374 0 0.0225"
             rpy="$(arg mount_rotation) 0 0" />
   </xacro:alpha_5_urdf>
@@ -53,6 +56,7 @@
   <xacro:alpha_5_system prefix="${prefix}"
                         serial_port="$(arg serial_port)"
                         initial_positions_file="$(arg initial_positions_file)"
+                        joint_limits_file="$(arg joint_limits_file)"
                         use_sim="${use_sim}"
                         use_mock_hardware="$(arg use_mock_hardware)" />
 

--- a/reach_description/description/alpha_5/urdf.xacro
+++ b/reach_description/description/alpha_5/urdf.xacro
@@ -2,7 +2,14 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="alpha_5_urdf"
-               params="parent prefix *origin mount_rotation:=^0">
+               params="parent prefix *origin joint_limits_file mount_rotation:=^0">
+
+    <!-- dynamically load the joint limits from a configuration file -->
+    <!-- this lets us modify a configuration file instead of requiring the implementation of a new URDF -->
+    <xacro:property name="joint_limits_file"
+                    default="$(arg joint_limits_file)" />
+    <xacro:property name="joint_limits"
+                    value="${xacro.load_yaml(joint_limits_file)['joint_limits']}" />
 
     <!-- links -->
     <!-- the distance from the mount center to the base_link is xyz="0.0374 0 0.0225" -->
@@ -261,8 +268,8 @@
       <origin xyz="0 0 0.014" />
       <axis xyz="0 0 1" />
       <limit effort="9.0"
-             lower="0.0"
-             upper="6.10"
+             lower="${joint_limits['axis_e']['min_position']}"
+             upper="${joint_limits['axis_e']['max_position']}"
              velocity="0.5" />
     </joint>
 
@@ -273,8 +280,8 @@
       <origin xyz="-0.02 0 0.033" />
       <axis xyz="0 1 0" />
       <limit effort="9.0"
-             lower="-3.49"
-             upper="3.49"
+             lower="${joint_limits['axis_d']['min_position']}"
+             upper="${joint_limits['axis_d']['max_position']}"
              velocity="0.5" />
     </joint>
 
@@ -286,8 +293,8 @@
               rpy="0 0 3.14159" />
       <axis xyz="0 1 0" />
       <limit effort="9.0"
-             lower="0.0"
-             upper="3.22"
+             lower="${joint_limits['axis_c']['min_position']}"
+             upper="${joint_limits['axis_c']['max_position']}"
              velocity="0.5" />
     </joint>
 
@@ -299,8 +306,8 @@
               rpy="0 0 2.09439" />
       <axis xyz="0 0 -1" />
       <limit effort="9.0"
-             lower="0.0"
-             upper="3.22"
+             lower="${joint_limits['axis_b']['min_position']}"
+             upper="${joint_limits['axis_b']['max_position']}"
              velocity="0.5" />
     </joint>
 
@@ -320,8 +327,8 @@
       <child link="${prefix}push_rod" />
       <axis xyz="0 0 1" />
       <limit effort="10"
-             lower="0"
-             upper="0.015"
+             lower="${joint_limits['axis_a']['min_position']}"
+             upper="${joint_limits['axis_a']['max_position']}"
              velocity="10" />
     </joint>
 

--- a/reach_hardware/src/alpha_5_hardware.cpp
+++ b/reach_hardware/src/alpha_5_hardware.cpp
@@ -258,11 +258,11 @@ auto Alpha5Hardware::read(const rclcpp::Time & /* time */, const rclcpp::Duratio
 
   for (const auto & [name, desc] : joint_state_interfaces_) {
     if (desc.interface_info.name == hardware_interface::HW_IF_POSITION) {
-      set_state(name, async_states_positions_[desc.prefix_name]);
+      set_state(name, static_cast<double>(async_states_positions_[desc.prefix_name]));
     } else if (desc.interface_info.name == hardware_interface::HW_IF_VELOCITY) {
-      set_state(name, async_states_velocities_[desc.prefix_name]);
+      set_state(name, static_cast<double>(async_states_velocities_[desc.prefix_name]));
     } else if (desc.interface_info.name == hardware_interface::HW_IF_EFFORT) {
-      set_state(name, async_states_efforts_[desc.prefix_name]);
+      set_state(name, static_cast<double>(async_states_efforts_[desc.prefix_name]));
     }
   }
 


### PR DESCRIPTION
## Changes Made

This PR replaces the static joint limits configured in the URDF with a configuration file. The limits are defined using the same format that MoveIt uses for their joint limits to make it cross-compatible. Note that this currently only integrates the position limits and velocity, acceleration, and effort limits should be added in the future.

## Associated Issues

Evan's sprint to experiments

## Testing

Testing done in sim
