### PR TITLE
Remove deprecated API and integrate minimal launch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         types_or: [c++, c]
 
   - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.13.5
+    rev: 0.21.0
     hooks:
     - id: gersemi
 

--- a/libreach/CHANGELOG.md
+++ b/libreach/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog for package libreach
+
+## 0.0.1 (2025-07-22)

--- a/libreach/CMakeLists.txt
+++ b/libreach/CMakeLists.txt
@@ -30,19 +30,19 @@ target_sources(
         src/udp_driver.cpp
     PUBLIC
         FILE_SET HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-        FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/client.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/device_id.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/driver.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/mode.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/packet_id.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/packet.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/serial_client.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/serial_driver.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/udp_client.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/udp_driver.hpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/version.hpp
+            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+            FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/client.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/device_id.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/driver.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/mode.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/packet_id.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/packet.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/serial_client.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/serial_driver.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/udp_client.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/udp_driver.hpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/libreach/version.hpp
 )
 
 target_compile_features(libreach PUBLIC cxx_std_23)

--- a/reach_bringup/CHANGELOG.md
+++ b/reach_bringup/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog for package reach_bringup
+
+## 0.0.1 (2025-07-22)

--- a/reach_bringup/README.md
+++ b/reach_bringup/README.md
@@ -6,6 +6,7 @@ each of the Reach Robotics devices.
 ## Reach Alpha 5 Launch
 
 * alpha_5.launch.yaml
+* alpha_5_minimal.launch.yaml
 
 ### Examples
 
@@ -19,6 +20,12 @@ each of the Reach Robotics devices.
 
   ```bash
   ros2 launch reach_bringup alpha_5.launch.yaml use_sim:=true
+  ```
+
+* For minimal installations without Gazebo or RViz, launch the system with
+
+  ```bash
+  ros2 launch reach_bringup alpha_5_minimal.launch.yaml
   ```
 
 ## Micro IP Camera Launch

--- a/reach_bringup/launch/alpha_5_minimal.launch.yaml
+++ b/reach_bringup/launch/alpha_5_minimal.launch.yaml
@@ -1,0 +1,57 @@
+launch:
+  - arg:
+      name: prefix
+      default: ""
+      description: "The prefix used in the robot description. This should be provided in the form `<prefix>/`."
+
+  - arg:
+      name: serial_port
+      default: /dev/ttyUSB0
+      description: "The serial port used to communicate with the robot, e.g., `/dev/ttyUSB0`."
+
+  - arg:
+      name: use_mock_hardware
+      default: "true"
+      description: "Use the mock hardware interface."
+
+  - arg:
+      name: parent_link
+      default: world
+      description: "The parent link of the robot. This is useful for affixing the Alpha 5 to another robot."
+
+  - arg:
+      name: description_file
+      default: $(find-pkg-share reach_description)/description/alpha_5/standard_jaws/alpha_5.config.xacro
+      description: "The robot description file."
+
+  - arg:
+      name: controllers_file
+      default: $(find-pkg-share reach_description)/config/alpha_5/controllers.yaml
+      description: "The ros2_control controllers configuration file."
+
+  - arg:
+      name: robot_description
+      default: $(command 'xacro $(var description_file) serial_port:=$(var serial_port) use_sim:=false prefix:=$(var prefix) use_mock_hardware:=$(var use_mock_hardware) parent:=$(var parent_link) controllers_file:=$(var controllers_file)')
+      description: "The robot description."
+
+  - arg:
+      name: robot_controller
+      default: forward_position_controller
+      description: "The robot controller to use."
+
+  - arg:
+      name: tcp_controller
+      default: tcp_position_controller
+      description: "The TCP controller to use."
+
+  - include:
+      file: $(find-pkg-share reach_bringup)/launch/minimal.launch.py
+      arg:
+        - name: controllers_file
+          value: $(var controllers_file)
+        - name: robot_controller
+          value: $(var robot_controller)
+        - name: tcp_controller
+          value: $(var tcp_controller)
+        - name: robot_description
+          value: $(var robot_description)

--- a/reach_bringup/launch/minimal.launch.py
+++ b/reach_bringup/launch/minimal.launch.py
@@ -1,0 +1,88 @@
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    RegisterEventHandler,
+)
+from launch.event_handlers import OnProcessExit, OnProcessStart
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    args = [
+        DeclareLaunchArgument("controllers_file"),
+        DeclareLaunchArgument("robot_controller"),
+        DeclareLaunchArgument("tcp_controller"),
+        DeclareLaunchArgument("robot_description"),
+    ]
+
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[{"robot_description": LaunchConfiguration("robot_description")}],
+    )
+
+    # ros2_control launch
+    controller_manager = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        output="both",
+        parameters=[LaunchConfiguration("controllers_file")],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster"],
+    )
+
+    robot_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[LaunchConfiguration("robot_controller")],
+    )
+
+    tcp_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[LaunchConfiguration("tcp_controller")],
+    )
+
+    # Delay joint_state_broadcaster after controller_manager
+    # This will not work if the controller_manager is not started (i.e., in simulation)
+    delay_jsb_spawner_after_controller_manager = RegisterEventHandler(
+        event_handler=OnProcessStart(
+            target_action=controller_manager,
+            on_start=[joint_state_broadcaster_spawner],
+        ),
+    )
+
+    # Delay start of robot_controller after `joint_state_broadcaster`
+    delay_robot_controller_spawners_after_jsb_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[robot_controller_spawner],
+        ),
+    )
+
+    # Delay start of tcp_controller after `joint_state_broadcaster`
+    delay_tcp_controller_spawners_after_jsb_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[tcp_controller_spawner],
+        ),
+    )
+
+    nodes = [
+        controller_manager,
+        robot_state_publisher,
+        delay_jsb_spawner_after_controller_manager,
+        delay_robot_controller_spawners_after_jsb_spawner,
+        delay_tcp_controller_spawners_after_jsb_spawner,
+    ]
+
+    return LaunchDescription(args + nodes)

--- a/reach_controllers/CHANGELOG.md
+++ b/reach_controllers/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog for package reach_controllers
+
+## 0.0.1 (2025-07-22)
+
+- Replaces deprecated `unlockAndPublish` and `trylock` with `try_publish`
+- Replaces deprecated `ament_target_dependencies` with `target_link_libraries`

--- a/reach_controllers/CMakeLists.txt
+++ b/reach_controllers/CMakeLists.txt
@@ -7,19 +7,13 @@ endif()
 
 include(GNUInstallDirs)
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-    controller_interface
-    hardware_interface
-    pluginlib
-    generate_parameter_library
-    realtime_tools
-    reach_msgs
-)
-
+find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(generate_parameter_library REQUIRED)
+find_package(realtime_tools REQUIRED)
+find_package(reach_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-    find_package(${Dependency} REQUIRED)
-endforeach()
 
 generate_parameter_library(impedance_controller_parameters
   src/impedance_controller_parameters.yaml
@@ -31,13 +25,23 @@ target_sources(
     PRIVATE src/impedance_controller.cpp
     PUBLIC
         FILE_SET HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-        FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/reach_controllers/impedance_controller.hpp
+            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+            FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/reach_controllers/impedance_controller.hpp
 )
 target_compile_features(reach_controllers PUBLIC cxx_std_20)
-target_link_libraries(reach_controllers PUBLIC impedance_controller_parameters)
-ament_target_dependencies(reach_controllers PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(
+    reach_controllers
+    PUBLIC
+        impedance_controller_parameters
+        controller_interface::controller_interface
+        hardware_interface::hardware_interface
+        hardware_interface::mock_components
+        pluginlib::pluginlib
+        realtime_tools::realtime_tools
+        realtime_tools::thread_priority
+        ${reach_msgs_TARGETS}
+)
 
 pluginlib_export_plugin_description_file(controller_interface reach_controllers.xml)
 
@@ -51,6 +55,13 @@ install(
 )
 
 ament_export_targets(export_reach_controllers HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_export_dependencies(
+  "controller_interface"
+  "hardware_interface"
+  "pluginlib"
+  "generate_parameter_library"
+  "realtime_tools"
+  "reach_msgs"
+)
 
 ament_package()

--- a/reach_controllers/include/reach_controllers/impedance_controller.hpp
+++ b/reach_controllers/include/reach_controllers/impedance_controller.hpp
@@ -109,7 +109,7 @@ protected:
   std::shared_ptr<rclcpp::Publisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>> controller_state_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>>
     rt_controller_state_pub_;
-  reach_msgs::msg::MultiDOFImpedanceStateStamped controller_state_msg_;
+  reach_msgs::msg::MultiDOFImpedanceStateStamped controller_state_;
 
   std::shared_ptr<impedance_controller::ParamListener> param_listener_;
   impedance_controller::Params params_;

--- a/reach_controllers/include/reach_controllers/impedance_controller.hpp
+++ b/reach_controllers/include/reach_controllers/impedance_controller.hpp
@@ -106,10 +106,10 @@ protected:
   realtime_tools::RealtimeBuffer<reach_msgs::msg::MultiDOFImpedanceCommand> reference_;
   std::shared_ptr<rclcpp::Subscription<reach_msgs::msg::MultiDOFImpedanceCommand>> reference_sub_;
 
-  std::shared_ptr<rclcpp::Publisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>> controller_state_pub_;
-  std::unique_ptr<realtime_tools::RealtimePublisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>>
-    rt_controller_state_pub_;
-  reach_msgs::msg::MultiDOFImpedanceStateStamped controller_state_;
+  using ControllerState = reach_msgs::msg::MultiDOFImpedanceStateStamped;
+  std::shared_ptr<rclcpp::Publisher<ControllerState>> controller_state_pub_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<ControllerState>> rt_controller_state_pub_;
+  ControllerState controller_state_;
 
   std::shared_ptr<impedance_controller::ParamListener> param_listener_;
   impedance_controller::Params params_;

--- a/reach_controllers/include/reach_controllers/impedance_controller.hpp
+++ b/reach_controllers/include/reach_controllers/impedance_controller.hpp
@@ -109,6 +109,7 @@ protected:
   std::shared_ptr<rclcpp::Publisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>> controller_state_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>>
     rt_controller_state_pub_;
+  reach_msgs::msg::MultiDOFImpedanceStateStamped controller_state_msg_;
 
   std::shared_ptr<impedance_controller::ParamListener> param_listener_;
   impedance_controller::Params params_;

--- a/reach_controllers/src/impedance_controller.cpp
+++ b/reach_controllers/src/impedance_controller.cpp
@@ -112,12 +112,9 @@ auto ImpedanceController::on_configure(const rclcpp_lifecycle::State & /*previou
       reference_.writeFromNonRT(*msg);
     });
 
-  controller_state_pub_ = get_node()->create_publisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>(
-    "~/status", rclcpp::SystemDefaultsQoS());
-
+  controller_state_pub_ = get_node()->create_publisher<ControllerState>("~/status", rclcpp::SystemDefaultsQoS());
   rt_controller_state_pub_ =
-    std::make_unique<realtime_tools::RealtimePublisher<reach_msgs::msg::MultiDOFImpedanceStateStamped>>(
-      controller_state_pub_);
+    std::make_unique<realtime_tools::RealtimePublisher<ControllerState>>(controller_state_pub_);
 
   auto p_terms = controller_gains_ | std::views::transform([](const auto & gains) { return gains.damping; });
   auto d_terms = controller_gains_ | std::views::transform([](const auto & gains) { return gains.stiffness; });

--- a/reach_description/CHANGELOG.md
+++ b/reach_description/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog for package reach_description
+
+## 0.0.1 (2025-07-22)

--- a/reach_hardware/CHANGELOG.md
+++ b/reach_hardware/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog for package reach_hardware
+
+## 0.0.1 (2025-07-22)
+
+- Replaces deprecated `ament_target_dependencies` with `target_link_libraries`

--- a/reach_hardware/CMakeLists.txt
+++ b/reach_hardware/CMakeLists.txt
@@ -7,18 +7,12 @@ endif()
 
 include(GNUInstallDirs)
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-    rclcpp
-    libreach
-    rclcpp_lifecycle
-    pluginlib
-    hardware_interface
-)
-
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(libreach REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(hardware_interface REQUIRED)
 find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-    find_package(${Dependency} REQUIRED)
-endforeach()
 
 add_library(reach_hardware SHARED)
 target_sources(
@@ -26,12 +20,21 @@ target_sources(
     PRIVATE src/alpha_5_hardware.cpp
     PUBLIC
         FILE_SET HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-        FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/reach_hardware/alpha_5_hardware.hpp
+            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+            FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/reach_hardware/alpha_5_hardware.hpp
 )
 target_compile_features(reach_hardware PUBLIC cxx_std_20)
-ament_target_dependencies(reach_hardware PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(
+    reach_hardware
+    PUBLIC
+        hardware_interface::hardware_interface
+        hardware_interface::mock_components
+        libreach::libreach
+        pluginlib::pluginlib
+        rclcpp::rclcpp
+        rclcpp_lifecycle::rclcpp_lifecycle
+)
 
 pluginlib_export_plugin_description_file(hardware_interface alpha_5_hardware.xml)
 
@@ -45,6 +48,12 @@ install(
 )
 
 ament_export_targets(export_reach_hardware HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_export_dependencies(
+  "rclcpp"
+  "rclcpp_lifecycle"
+  "libreach"
+  "pluginlib"
+  "hardware_interface"
+)
 
 ament_package()

--- a/reach_hardware/include/reach_hardware/alpha_5_hardware.hpp
+++ b/reach_hardware/include/reach_hardware/alpha_5_hardware.hpp
@@ -50,7 +50,8 @@ namespace reach::hardware
 class Alpha5Hardware : public hardware_interface::SystemInterface
 {
 public:
-  auto on_init(const hardware_interface::HardwareInfo & info) -> hardware_interface::CallbackReturn override;
+  auto on_init(const hardware_interface::HardwareComponentInterfaceParams & info)
+    -> hardware_interface::CallbackReturn override;
 
   auto on_configure(const rclcpp_lifecycle::State & previous_state) -> hardware_interface::CallbackReturn override;
 

--- a/reach_hardware/src/alpha_5_hardware.cpp
+++ b/reach_hardware/src/alpha_5_hardware.cpp
@@ -77,7 +77,8 @@ auto validate_interfaces(
 
 }  // namespace
 
-auto Alpha5Hardware::on_init(const hardware_interface::HardwareInfo & info) -> hardware_interface::CallbackReturn
+auto Alpha5Hardware::on_init(const hardware_interface::HardwareComponentInterfaceParams & info)
+  -> hardware_interface::CallbackReturn
 {
   RCLCPP_INFO(logger_, "Initializing Alpha5Hardware system interface");
 

--- a/reach_ip_camera/CHANGELOG.md
+++ b/reach_ip_camera/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog for package reach_ip_camera
+
+## 0.0.1 (2025-07-22)
+
+- Replaces deprecated `ament_target_dependencies` with `target_link_libraries`

--- a/reach_ip_camera/CMakeLists.txt
+++ b/reach_ip_camera/CMakeLists.txt
@@ -7,19 +7,12 @@ endif()
 
 include(GNUInstallDirs)
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-    rclcpp
-    geometry_msgs
-    rclcpp_components
-    cv_bridge
-    camera_info_manager
-    image_transport
-)
-
-foreach(pkg IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-    find_package(${pkg} REQUIRED)
-endforeach()
-
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(camera_info_manager REQUIRED)
+find_package(image_transport REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 
@@ -38,9 +31,9 @@ target_sources(
     PRIVATE src/gstreamer_proxy.cpp
     PUBLIC
         FILE_SET HEADERS
-        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-        FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/include/reach_ip_camera/gstreamer_proxy.hpp
+            BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+            FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/include/reach_ip_camera/gstreamer_proxy.hpp
 )
 target_link_libraries(
     gstreamer_proxy_library
@@ -48,8 +41,18 @@ target_link_libraries(
     PUBLIC PkgConfig::gstreamer
     PUBLIC PkgConfig::gstreamer-app
 )
-ament_target_dependencies(gstreamer_proxy_library PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_compile_features(gstreamer_proxy_library PUBLIC cxx_std_20)
+target_link_libraries(
+    gstreamer_proxy_library
+    PUBLIC
+        camera_info_manager::camera_info_manager
+        cv_bridge::cv_bridge
+        image_transport::image_transport
+        rclcpp::rclcpp
+        rclcpp_components::component
+        rclcpp_components::component_manager
+        ${geometry_msgs_TARGETS}
+)
 
 rclcpp_components_register_node(gstreamer_proxy_library
     PLUGIN "reach::GStreamerProxy"
@@ -66,6 +69,13 @@ install(
 )
 
 ament_export_targets(export_gstreamer_proxy_library HAS_LIBRARY_TARGET)
-ament_export_dependencies($THIS_PACKAGE_INCLUDE_DEPENDS)
+ament_export_dependencies(
+  "rclcpp"
+  "geometry_msgs"
+  "rclcpp_components"
+  "cv_bridge"
+  "camera_info_manager"
+  "image_transport"
+)
 
 ament_package()

--- a/reach_msgs/CHANGELOG.md
+++ b/reach_msgs/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog for package reach_msgs
+
+## 0.0.1 (2025-07-22)


### PR DESCRIPTION
## Changes Made

This PR removes elements of the ros2_control API that have been deprecated. Additionally, a new launch file was added that does not depend on Gazebo or RViz, allowing minimal installations to still launch the system.

## Testing

TBD
